### PR TITLE
Deployment process with a docker image starting the output build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,7 @@ bld/
 [Bb]in/
 [Oo]bj/
 [Ll]og/
+output
 
 # Visual Studio 2015 cache/options directory
 .vs/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/dotnet/core/runtime:3.1 AS base
+FROM mcr.microsoft.com/dotnet/core/runtime:7.0 AS base
 
 WORKDIR /bot
 COPY ./output ./

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,5 @@
+FROM mcr.microsoft.com/dotnet/core/runtime:3.1 AS base
+
+WORKDIR /bot
+COPY ./output ./
+ENTRYPOINT ["./GothmogBot"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/dotnet/core/runtime:7.0 AS base
+FROM mcr.microsoft.com/dotnet/runtime-deps
 
 WORKDIR /bot
 COPY ./output ./

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,9 @@
+build:
+	dotnet publish src/GothmogBot/GothmogBot.csproj -c Release -r linux-x64 -o ./output --sc true -p:DebugType=None -p:DebugSymbols=false --self-contained
+
+upload:
+	rsync -av --no-perms --delete output/ philaeux@luna.the-cluster.org:/home/philaeux/gothmog-bot/output
+
+deploy:
+	git pull
+	docker compose up --build -d

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,0 +1,4 @@
+version: '3'
+services:
+  bot:
+    build: .

--- a/src/GothmogBot/local.settings.template.json
+++ b/src/GothmogBot/local.settings.template.json
@@ -1,5 +1,8 @@
 {
   "DiscordOptions": {
     "DiscordApiToken": "<Discord API Token>"
+  },
+  "StratzOptions": {
+    "StratzApiToken": "<Stratz API Token>"
   }
 }


### PR DESCRIPTION
Adds build to make a self-contained linux_x64 in output dir.
Adds output dir to gitignore.
Adds missing option to the local.settings.template.json.
Adds a simple Docker image to start the app, and a docker compose in case we want linked images in the future (like a postgres db).
Puts the commands in a Makefile to simply my deployment process.
